### PR TITLE
Add check service principal workflow

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -14,11 +14,10 @@ jobs:
       - name: Select Tests
         id: select-tests
         run: |
-          d="{'environment':'dev', 'principal': 's165d01-trngen-keyvault-readonly-access', 'keyvault': 's165d01-trngen-dv-kv'}"
-          t="{'environment':'test', 'principal': 's165t01-trngen-keyvault-readonly-access', 'keyvault': 's165t01-trngen-pp-kv'}"
-          pp="{'environment':'preprod', 'principal': 's165t01-trngen-keyvault-readonly-access', 'keyvault': 's165t01-trngen-pp-kv'}"
-          p="{'environment':'production', 'principal': 's165p01-trngen-keyvault-readonly-access', 'keyvault': 's165p01-trngen-pd-kv'}"
-          tests="{ 'data':[ ${d},  ${t},  ${pp},  ${p} ]}"
+          d="{'environment':'dev', 'principal': 's165d01-dqt-contributor', 'keyvault': 's165d01-dv-kv'}"
+          t="{'environment':'test', 'principal': 's165t01-dqt-contributor', 'keyvault': 's165t01-pp-kv'}"
+          p="{'environment':'production', 'principal': 's165p01-dqt-contributor', 'keyvault': 's165p01-pd-kv'}"
+          tests="{ 'data':[ ${d},  ${t},  ${p} ]}"
           echo "tests=${tests}" >> $GITHUB_OUTPUT
   check_expires:
     name: ${{matrix.data.environment}}/${{ matrix.data.principal }}


### PR DESCRIPTION
Context

The workflows are dependent on Service Principals (SP) with secrets that are time-limited; therefore, we would check for the expiry of such secrets.

Changes proposed in this pull request

This workflow will check the date of expiry of the Service Principal in dev, test and production environments. The check will look for SP's that are expiring in less than 30 days and will trigger an alert in Slack

Guidance to review

Check logs for test run[ here](https://github.com/DFE-Digital/tra-trn-generation-api/actions/runs/3800027540)

Checklist

Attach to Trello card
Rebased main
Cleaned commit history