### PR TITLE
Remove lint step from PR workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,6 @@ jobs:
         with:
           dotnet-version: "7.0.x"
 
-      - name: Lint
-        run: |
-          #https://github.com/dotnet/format/issues/1433
-          dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
-          dotnet-format --verify-no-changes
-        working-directory: TrnGeneratorApi
-
       - name: Build
         run: dotnet build --configuration Release
         working-directory: TrnGeneratorApi


### PR DESCRIPTION
The lint step is failing but this repo is effectively in maintenance mode (its functionality will be moved into TRS itself at some point) so we don't really need it any more.